### PR TITLE
fix: desativar cache do WhatsApp Web para evitar erros de sessão

### DIFF
--- a/bot/index.js
+++ b/bot/index.js
@@ -86,8 +86,6 @@ async function processarFila() {
 
 // --- Configuração do client WhatsApp ---
 const client = new Client({
-    authStrategy: new LocalAuth(),
-
     // ↓ ATUALIZAÇÕES AQUI ↓ -----------------------------------------------------------------------------------------------------------
     authStrategy: new LocalAuth({
         clientId: 'mix-rub' // essa parte vai isolar a sessão pra não dar mais aquele bug de cache.

--- a/bot/index.js
+++ b/bot/index.js
@@ -87,6 +87,14 @@ async function processarFila() {
 // --- Configuração do client WhatsApp ---
 const client = new Client({
     authStrategy: new LocalAuth(),
+
+    // ↓ ATUALIZAÇÕES AQUI ↓ -----------------------------------------------------------------------------------------------------------
+    authStrategy: new LocalAuth({
+        clientId: 'mix-rub' // essa parte vai isolar a sessão pra não dar mais aquele bug de cache.
+    }),                                                                                                            // Deixa o like kkkkkkkkk
+    webVersionCache: { type: 'none' }, // desativa cache da versão do WA Web deixando mais limpo. Mas recomendo fazer testes primeiro.
+    // ↑ FECHA ATUALIZAÇÃO AQUI ↑  ----------------------------------------------------------------------------------------------------
+
     puppeteer: {
         executablePath: 'C:\\Program Files\\Google\\Chrome\\Application\\chrome.exe',
         headless: true,


### PR DESCRIPTION
Adicionado clientId no LocalAuth e desativado webVersionCache para evitar conflitos de cache e misturar sessões.

Essa atualização foi feita em: // --- Configuração do client WhatsApp ---